### PR TITLE
[Feat] Add an easy way to rename input/output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ betas = "0.9,0.99"
 
 As you can see everything is sectioned off into their own sections. Generally they are seperated into two groups, args, and dataset_args, this is because of the nature of the config and dataset_confg files within sd-scripts. Generally speaking, the only section that you might want to edit that doesn't correspond to a UI element (for now) is the `[optimizer_args.args.optimizer_args]` section, which you can add, delete, or change options for the optimizer, A proper UI for it will come later, once I figure out how I want to set it up.
 
+## Development
+
+```bash
+# Use this edit the UI
+pip install pyqt6-tools # Install
+pyqt6-tools designer # Run
+
+# After editing a .ui file, compile it to a .py file in the ui_files/ directory
+pyside6-uic ui_files/SavingUI.ui -o ui_files/SavingUI.py
+```
+
 ## Changelog
 
 changelog of the old scripts are all in that branch [here](https://github.com/derrian-distro/LoRA_Easy_Training_Scripts/tree/old-scripts#changelog)

--- a/main_ui_files/MainUI.py
+++ b/main_ui_files/MainUI.py
@@ -123,6 +123,32 @@ class MainWidget(QWidget):
             self.train_mode = TrainingModes.TI
             self.args_widget.set_ti_training()
 
+    def perform_easy_naming(self, args:dict) -> dict:
+        """
+        Replaces the baseName variable with the easy_name variable in various saving and logging paths.
+        """
+        base_name_var = r"${baseName}"
+
+        saving_args = args.get("saving_args", {})
+        easy_name = saving_args.get("easy_name", "")
+
+        if "output_dir" in saving_args:
+            saving_args["output_dir"] = saving_args["output_dir"].replace(base_name_var, easy_name)
+        if "output_name" in saving_args:
+            saving_args["output_name"] = saving_args["output_name"].replace(base_name_var, easy_name)
+        if "tag_file_location" in saving_args:
+            saving_args["tag_file_location"] = saving_args["tag_file_location"].replace(base_name_var, easy_name)
+        if "save_toml_location" in saving_args:
+            saving_args["save_toml_location"] = saving_args["save_toml_location"].replace(base_name_var, easy_name)
+        if "resume" in saving_args:
+            saving_args["resume"] = saving_args["resume"].replace(base_name_var, easy_name)
+
+        logging_args = args.get("logging_args", {})
+        if "log_prefix" in logging_args:
+            logging_args["log_prefix"] = logging_args["log_prefix"].replace(base_name_var, easy_name)
+
+        return args
+
     def process_toml(self, file_name: Path | None = None) -> tuple[dict, dict]:
         loaded_args = TomlFunctions.load_toml(file_name)
         if not loaded_args:
@@ -142,6 +168,7 @@ class MainWidget(QWidget):
                 args[arg] = val["args"]
             if "dataset_args" in val:
                 dataset_args[arg] = val["dataset_args"]
+        
         return args, dataset_args, train_mode
 
     def start_training(self) -> None:
@@ -173,7 +200,10 @@ class MainWidget(QWidget):
 
     def train_helper(self, url: str, train_toml: Path) -> bool:
         args, dataset_args, train_mode = self.process_toml(train_toml)
-        final_args = {"args": args, "dataset": dataset_args}
+        final_args = {
+            "args": self.perform_easy_naming(args), 
+            "dataset": dataset_args
+        }
         config = json.loads(Path("config.json").read_text())
         try:
             response = requests.post(

--- a/main_ui_files/MainUI.py
+++ b/main_ui_files/MainUI.py
@@ -123,29 +123,29 @@ class MainWidget(QWidget):
             self.train_mode = TrainingModes.TI
             self.args_widget.set_ti_training()
 
-    def perform_easy_naming(self, args:dict) -> dict:
+    def perform_name_replace(self, args:dict) -> dict:
         """
-        Replaces the baseName variable with the easy_name variable in various saving and logging paths.
+        Replaces the $replace variable with the name_replace variable in various saving and logging paths.
         """
-        base_name_var = r"${baseName}"
+        template_str = r"${replace}"
 
         saving_args = args.get("saving_args", {})
-        easy_name = saving_args.get("easy_name", "")
+        replace_str = saving_args.get("name_replace", "")
 
         if "output_dir" in saving_args:
-            saving_args["output_dir"] = saving_args["output_dir"].replace(base_name_var, easy_name)
+            saving_args["output_dir"] = saving_args["output_dir"].replace(template_str, replace_str)
         if "output_name" in saving_args:
-            saving_args["output_name"] = saving_args["output_name"].replace(base_name_var, easy_name)
+            saving_args["output_name"] = saving_args["output_name"].replace(template_str, replace_str)
         if "tag_file_location" in saving_args:
-            saving_args["tag_file_location"] = saving_args["tag_file_location"].replace(base_name_var, easy_name)
+            saving_args["tag_file_location"] = saving_args["tag_file_location"].replace(template_str, replace_str)
         if "save_toml_location" in saving_args:
-            saving_args["save_toml_location"] = saving_args["save_toml_location"].replace(base_name_var, easy_name)
+            saving_args["save_toml_location"] = saving_args["save_toml_location"].replace(template_str, replace_str)
         if "resume" in saving_args:
-            saving_args["resume"] = saving_args["resume"].replace(base_name_var, easy_name)
+            saving_args["resume"] = saving_args["resume"].replace(template_str, replace_str)
 
         logging_args = args.get("logging_args", {})
         if "log_prefix" in logging_args:
-            logging_args["log_prefix"] = logging_args["log_prefix"].replace(base_name_var, easy_name)
+            logging_args["log_prefix"] = logging_args["log_prefix"].replace(template_str, replace_str)
 
         return args
 
@@ -201,7 +201,7 @@ class MainWidget(QWidget):
     def train_helper(self, url: str, train_toml: Path) -> bool:
         args, dataset_args, train_mode = self.process_toml(train_toml)
         final_args = {
-            "args": self.perform_easy_naming(args), 
+            "args": self.perform_name_replace(args), 
             "dataset": dataset_args
         }
         config = json.loads(Path("config.json").read_text())

--- a/main_ui_files/SavingUI.py
+++ b/main_ui_files/SavingUI.py
@@ -41,7 +41,7 @@ class SavingWidget(BaseWidget):
         self.widget.save_toml_input.skip_validation_check = True
 
     def setup_connections(self) -> None:
-        self.widget.easy_naming_text_input.textChanged.connect(
+        self.widget.name_replace_text_input.textChanged.connect(
             lambda x: self.edit_args("easy_name", x, optional=True)
         )
         self.widget.output_folder_input.textChanged.connect(
@@ -275,7 +275,7 @@ class SavingWidget(BaseWidget):
         args: dict = args.get(self.name, {})
 
         # update element inputs
-        self.widget.easy_naming_text_input.setText(args.get("easy_name", ""))
+        self.widget.name_replace_text_input.setText(args.get("name_replace", ""))
         self.widget.output_folder_input.setText(args.get("output_dir", ""))
         self.widget.output_name_enable.setChecked(bool(args.get("output_name", False)))
         self.widget.output_name_input.setText(args.get("output_name", ""))
@@ -330,7 +330,7 @@ class SavingWidget(BaseWidget):
         )
 
         # edit args to match
-        self.edit_args("easy_name", self.widget.easy_naming_text_input.text(), True)
+        self.edit_args("name_replace", self.widget.name_replace_text_input.text(), True)
         self.edit_args(
             "output_dir",
             self.widget.output_folder_input.text(),

--- a/main_ui_files/SavingUI.py
+++ b/main_ui_files/SavingUI.py
@@ -29,7 +29,7 @@ class SavingWidget(BaseWidget):
             elem.highlight = True
             elem.allow_empty = True
             selector.setIcon(selector_icon)
-
+        
         setup_folder(
             self.widget.output_folder_input, self.widget.output_folder_selector
         )
@@ -41,6 +41,9 @@ class SavingWidget(BaseWidget):
         self.widget.save_toml_input.skip_validation_check = True
 
     def setup_connections(self) -> None:
+        self.widget.easy_naming_text_input.textChanged.connect(
+            lambda x: self.edit_args("easy_name", x, optional=True)
+        )
         self.widget.output_folder_input.textChanged.connect(
             lambda x: self.edit_args("output_dir", x, optional=True)
         )
@@ -272,6 +275,7 @@ class SavingWidget(BaseWidget):
         args: dict = args.get(self.name, {})
 
         # update element inputs
+        self.widget.easy_naming_text_input.setText(args.get("easy_name", ""))
         self.widget.output_folder_input.setText(args.get("output_dir", ""))
         self.widget.output_name_enable.setChecked(bool(args.get("output_name", False)))
         self.widget.output_name_input.setText(args.get("output_name", ""))
@@ -326,6 +330,7 @@ class SavingWidget(BaseWidget):
         )
 
         # edit args to match
+        self.edit_args("easy_name", self.widget.easy_naming_text_input.text(), True)
         self.edit_args(
             "output_dir",
             self.widget.output_folder_input.text(),

--- a/ui_files/SavingUI.py
+++ b/ui_files/SavingUI.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'SavingUI.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.1
+## Created by: Qt User Interface Compiler version 6.8.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,123 +27,10 @@ class Ui_saving_ui(object):
     def setupUi(self, saving_ui):
         if not saving_ui.objectName():
             saving_ui.setObjectName(u"saving_ui")
-        saving_ui.resize(515, 242)
+        saving_ui.resize(515, 296)
         saving_ui.setMinimumSize(QSize(515, 0))
         self.gridLayout_2 = QGridLayout(saving_ui)
         self.gridLayout_2.setObjectName(u"gridLayout_2")
-        self.formLayout_3 = QFormLayout()
-        self.formLayout_3.setObjectName(u"formLayout_3")
-        self.label_2 = QLabel(saving_ui)
-        self.label_2.setObjectName(u"label_2")
-
-        self.formLayout_3.setWidget(0, QFormLayout.LabelRole, self.label_2)
-
-        self.save_precision_selector = ComboBox(saving_ui)
-        self.save_precision_selector.addItem("")
-        self.save_precision_selector.addItem("")
-        self.save_precision_selector.addItem("")
-        self.save_precision_selector.setObjectName(u"save_precision_selector")
-        self.save_precision_selector.setFocusPolicy(Qt.StrongFocus)
-
-        self.formLayout_3.setWidget(0, QFormLayout.FieldRole, self.save_precision_selector)
-
-        self.label_3 = QLabel(saving_ui)
-        self.label_3.setObjectName(u"label_3")
-
-        self.formLayout_3.setWidget(1, QFormLayout.LabelRole, self.label_3)
-
-        self.save_as_selector = ComboBox(saving_ui)
-        self.save_as_selector.addItem("")
-        self.save_as_selector.addItem("")
-        self.save_as_selector.addItem("")
-        self.save_as_selector.setObjectName(u"save_as_selector")
-        self.save_as_selector.setFocusPolicy(Qt.StrongFocus)
-
-        self.formLayout_3.setWidget(1, QFormLayout.FieldRole, self.save_as_selector)
-
-        self.save_ratio_enable = QCheckBox(saving_ui)
-        self.save_ratio_enable.setObjectName(u"save_ratio_enable")
-
-        self.formLayout_3.setWidget(2, QFormLayout.LabelRole, self.save_ratio_enable)
-
-        self.save_ratio_input = SpinBox(saving_ui)
-        self.save_ratio_input.setObjectName(u"save_ratio_input")
-        self.save_ratio_input.setEnabled(False)
-        self.save_ratio_input.setFocusPolicy(Qt.StrongFocus)
-        self.save_ratio_input.setMinimum(1)
-        self.save_ratio_input.setValue(1)
-
-        self.formLayout_3.setWidget(2, QFormLayout.FieldRole, self.save_ratio_input)
-
-        self.save_freq_enable = QCheckBox(saving_ui)
-        self.save_freq_enable.setObjectName(u"save_freq_enable")
-
-        self.formLayout_3.setWidget(3, QFormLayout.LabelRole, self.save_freq_enable)
-
-        self.horizontalLayout_2 = QHBoxLayout()
-        self.horizontalLayout_2.setSpacing(3)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.save_freq_selector = ComboBox(saving_ui)
-        self.save_freq_selector.addItem("")
-        self.save_freq_selector.addItem("")
-        self.save_freq_selector.setObjectName(u"save_freq_selector")
-        self.save_freq_selector.setEnabled(False)
-        self.save_freq_selector.setFocusPolicy(Qt.StrongFocus)
-
-        self.horizontalLayout_2.addWidget(self.save_freq_selector)
-
-        self.save_freq_input = SpinBox(saving_ui)
-        self.save_freq_input.setObjectName(u"save_freq_input")
-        self.save_freq_input.setEnabled(False)
-        self.save_freq_input.setFocusPolicy(Qt.StrongFocus)
-        self.save_freq_input.setMinimum(1)
-        self.save_freq_input.setMaximum(16777215)
-
-        self.horizontalLayout_2.addWidget(self.save_freq_input)
-
-
-        self.formLayout_3.setLayout(3, QFormLayout.FieldRole, self.horizontalLayout_2)
-
-
-        self.gridLayout_2.addLayout(self.formLayout_3, 1, 0, 1, 1)
-
-        self.formLayout_2 = QFormLayout()
-        self.formLayout_2.setObjectName(u"formLayout_2")
-        self.label = QLabel(saving_ui)
-        self.label.setObjectName(u"label")
-
-        self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.label)
-
-        self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setSpacing(3)
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.output_folder_input = DragDropLineEdit(saving_ui)
-        self.output_folder_input.setObjectName(u"output_folder_input")
-
-        self.horizontalLayout.addWidget(self.output_folder_input)
-
-        self.output_folder_selector = QPushButton(saving_ui)
-        self.output_folder_selector.setObjectName(u"output_folder_selector")
-
-        self.horizontalLayout.addWidget(self.output_folder_selector)
-
-
-        self.formLayout_2.setLayout(0, QFormLayout.FieldRole, self.horizontalLayout)
-
-        self.output_name_enable = QCheckBox(saving_ui)
-        self.output_name_enable.setObjectName(u"output_name_enable")
-
-        self.formLayout_2.setWidget(1, QFormLayout.LabelRole, self.output_name_enable)
-
-        self.output_name_input = LineEditWithHighlight(saving_ui)
-        self.output_name_input.setObjectName(u"output_name_input")
-        self.output_name_input.setEnabled(False)
-
-        self.formLayout_2.setWidget(1, QFormLayout.FieldRole, self.output_name_input)
-
-
-        self.gridLayout_2.addLayout(self.formLayout_2, 0, 0, 1, 2)
-
         self.formLayout_4 = QFormLayout()
         self.formLayout_4.setObjectName(u"formLayout_4")
         self.save_state_enable = QCheckBox(saving_ui)
@@ -188,6 +75,54 @@ class Ui_saving_ui(object):
 
 
         self.gridLayout_2.addLayout(self.formLayout_4, 2, 0, 1, 2)
+
+        self.formLayout_2 = QFormLayout()
+        self.formLayout_2.setObjectName(u"formLayout_2")
+        self.label = QLabel(saving_ui)
+        self.label.setObjectName(u"label")
+
+        self.formLayout_2.setWidget(1, QFormLayout.LabelRole, self.label)
+
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setSpacing(3)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.output_folder_input = DragDropLineEdit(saving_ui)
+        self.output_folder_input.setObjectName(u"output_folder_input")
+
+        self.horizontalLayout.addWidget(self.output_folder_input)
+
+        self.output_folder_selector = QPushButton(saving_ui)
+        self.output_folder_selector.setObjectName(u"output_folder_selector")
+
+        self.horizontalLayout.addWidget(self.output_folder_selector)
+
+
+        self.formLayout_2.setLayout(1, QFormLayout.FieldRole, self.horizontalLayout)
+
+        self.output_name_enable = QCheckBox(saving_ui)
+        self.output_name_enable.setObjectName(u"output_name_enable")
+
+        self.formLayout_2.setWidget(2, QFormLayout.LabelRole, self.output_name_enable)
+
+        self.output_name_input = LineEditWithHighlight(saving_ui)
+        self.output_name_input.setObjectName(u"output_name_input")
+        self.output_name_input.setEnabled(False)
+
+        self.formLayout_2.setWidget(2, QFormLayout.FieldRole, self.output_name_input)
+
+        self.easy_naming_label = QLabel(saving_ui)
+        self.easy_naming_label.setObjectName(u"easy_naming_label")
+        self.easy_naming_label.setMinimumSize(QSize(97, 0))
+
+        self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.easy_naming_label)
+
+        self.easy_naming_text_input = LineEditWithHighlight(saving_ui)
+        self.easy_naming_text_input.setObjectName(u"easy_naming_text_input")
+
+        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.easy_naming_text_input)
+
+
+        self.gridLayout_2.addLayout(self.formLayout_2, 0, 0, 1, 2)
 
         self.formLayout = QFormLayout()
         self.formLayout.setObjectName(u"formLayout")
@@ -289,6 +224,82 @@ class Ui_saving_ui(object):
 
         self.gridLayout_2.addLayout(self.formLayout, 1, 1, 1, 1)
 
+        self.formLayout_3 = QFormLayout()
+        self.formLayout_3.setObjectName(u"formLayout_3")
+        self.label_2 = QLabel(saving_ui)
+        self.label_2.setObjectName(u"label_2")
+
+        self.formLayout_3.setWidget(0, QFormLayout.LabelRole, self.label_2)
+
+        self.save_precision_selector = ComboBox(saving_ui)
+        self.save_precision_selector.addItem("")
+        self.save_precision_selector.addItem("")
+        self.save_precision_selector.addItem("")
+        self.save_precision_selector.setObjectName(u"save_precision_selector")
+        self.save_precision_selector.setFocusPolicy(Qt.StrongFocus)
+
+        self.formLayout_3.setWidget(0, QFormLayout.FieldRole, self.save_precision_selector)
+
+        self.label_3 = QLabel(saving_ui)
+        self.label_3.setObjectName(u"label_3")
+
+        self.formLayout_3.setWidget(1, QFormLayout.LabelRole, self.label_3)
+
+        self.save_as_selector = ComboBox(saving_ui)
+        self.save_as_selector.addItem("")
+        self.save_as_selector.addItem("")
+        self.save_as_selector.addItem("")
+        self.save_as_selector.setObjectName(u"save_as_selector")
+        self.save_as_selector.setFocusPolicy(Qt.StrongFocus)
+
+        self.formLayout_3.setWidget(1, QFormLayout.FieldRole, self.save_as_selector)
+
+        self.save_ratio_enable = QCheckBox(saving_ui)
+        self.save_ratio_enable.setObjectName(u"save_ratio_enable")
+
+        self.formLayout_3.setWidget(2, QFormLayout.LabelRole, self.save_ratio_enable)
+
+        self.save_ratio_input = SpinBox(saving_ui)
+        self.save_ratio_input.setObjectName(u"save_ratio_input")
+        self.save_ratio_input.setEnabled(False)
+        self.save_ratio_input.setFocusPolicy(Qt.StrongFocus)
+        self.save_ratio_input.setMinimum(1)
+        self.save_ratio_input.setValue(1)
+
+        self.formLayout_3.setWidget(2, QFormLayout.FieldRole, self.save_ratio_input)
+
+        self.save_freq_enable = QCheckBox(saving_ui)
+        self.save_freq_enable.setObjectName(u"save_freq_enable")
+
+        self.formLayout_3.setWidget(3, QFormLayout.LabelRole, self.save_freq_enable)
+
+        self.horizontalLayout_2 = QHBoxLayout()
+        self.horizontalLayout_2.setSpacing(3)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.save_freq_selector = ComboBox(saving_ui)
+        self.save_freq_selector.addItem("")
+        self.save_freq_selector.addItem("")
+        self.save_freq_selector.setObjectName(u"save_freq_selector")
+        self.save_freq_selector.setEnabled(False)
+        self.save_freq_selector.setFocusPolicy(Qt.StrongFocus)
+
+        self.horizontalLayout_2.addWidget(self.save_freq_selector)
+
+        self.save_freq_input = SpinBox(saving_ui)
+        self.save_freq_input.setObjectName(u"save_freq_input")
+        self.save_freq_input.setEnabled(False)
+        self.save_freq_input.setFocusPolicy(Qt.StrongFocus)
+        self.save_freq_input.setMinimum(1)
+        self.save_freq_input.setMaximum(16777215)
+
+        self.horizontalLayout_2.addWidget(self.save_freq_input)
+
+
+        self.formLayout_3.setLayout(3, QFormLayout.FieldRole, self.horizontalLayout_2)
+
+
+        self.gridLayout_2.addLayout(self.formLayout_3, 1, 0, 1, 1)
+
 
         self.retranslateUi(saving_ui)
 
@@ -298,43 +309,21 @@ class Ui_saving_ui(object):
     def retranslateUi(self, saving_ui):
         saving_ui.setWindowTitle(QCoreApplication.translate("saving_ui", u"Form", None))
 #if QT_CONFIG(tooltip)
-        self.label_2.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision</p></body></html>", None))
+        self.save_state_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save State is how you save the training state so you can resume later</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.label_2.setText(QCoreApplication.translate("saving_ui", u"Save Precision", None))
-        self.save_precision_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"fp16", None))
-        self.save_precision_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"bf16", None))
-        self.save_precision_selector.setItemText(2, QCoreApplication.translate("saving_ui", u"float", None))
+        self.save_state_enable.setText(QCoreApplication.translate("saving_ui", u"Save State", None))
+#if QT_CONFIG(tooltip)
+        self.save_last_state_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.save_last_state_enable.setText(QCoreApplication.translate("saving_ui", u"Save Last State", None))
+        self.save_last_state_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"Epochs", None))
+        self.save_last_state_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"Steps", None))
 
 #if QT_CONFIG(tooltip)
-        self.save_precision_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision</p></body></html>", None))
+        self.save_last_state_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
-        self.label_3.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save As is the file type you save the file as. Typically you'll want to save as safetensors</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_3.setText(QCoreApplication.translate("saving_ui", u"Save As", None))
-        self.save_as_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"safetensors", None))
-        self.save_as_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"pt", None))
-        self.save_as_selector.setItemText(2, QCoreApplication.translate("saving_ui", u"ckpt", None))
-
-#if QT_CONFIG(tooltip)
-        self.save_as_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save As is the file type you save the file as. Typically you'll want to save as safetensors</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(tooltip)
-        self.save_ratio_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Ratio is the way to limit the number of models saved</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.save_ratio_enable.setText(QCoreApplication.translate("saving_ui", u"Save Ratio", None))
-#if QT_CONFIG(tooltip)
-        self.save_ratio_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Ratio is the way to limit the number of models saved</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.save_freq_enable.setText(QCoreApplication.translate("saving_ui", u"Save Freq", None))
-        self.save_freq_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"Epochs", None))
-        self.save_freq_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"Steps", None))
-
-#if QT_CONFIG(tooltip)
-        self.save_freq_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(tooltip)
-        self.save_freq_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.</p></body></html>", None))
+        self.save_last_state_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
         self.label.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Output Folder is the location the models are saved to</p></body></html>", None))
@@ -357,22 +346,13 @@ class Ui_saving_ui(object):
 #endif // QT_CONFIG(tooltip)
         self.output_name_input.setPlaceholderText(QCoreApplication.translate("saving_ui", u"Output Name", None))
 #if QT_CONFIG(tooltip)
-        self.save_state_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save State is how you save the training state so you can resume later</p></body></html>", None))
+        self.easy_naming_label.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Easily rename all instances of ${baseName} variable in files/folders under Saving and Logging</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.save_state_enable.setText(QCoreApplication.translate("saving_ui", u"Save State", None))
+        self.easy_naming_label.setText(QCoreApplication.translate("saving_ui", u"Easy Naming", None))
 #if QT_CONFIG(tooltip)
-        self.save_last_state_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
+        self.easy_naming_text_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>What to replace all instances of ${baseName} with. To use, add ${baseName} in each desired textbox</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.save_last_state_enable.setText(QCoreApplication.translate("saving_ui", u"Save Last State", None))
-        self.save_last_state_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"Epochs", None))
-        self.save_last_state_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"Steps", None))
-
-#if QT_CONFIG(tooltip)
-        self.save_last_state_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(tooltip)
-        self.save_last_state_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Last State is much like Save Only Last in that it will keep only the last epoch or step number of states</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
+        self.easy_naming_text_input.setPlaceholderText(QCoreApplication.translate("saving_ui", u"Base name for model", None))
 #if QT_CONFIG(tooltip)
         self.resume_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Resume State resumes training at a previous training, assuming you save the state for that bake</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
@@ -422,5 +402,44 @@ class Ui_saving_ui(object):
         self.save_tag_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Tag File saves a txt file that contains a list of all tags within the dataset sorted by tag count. If enabled but no folder is provided, The default location will be in a folder called auto_save_store</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.save_tag_enable.setText(QCoreApplication.translate("saving_ui", u"Save Tag File", None))
+#if QT_CONFIG(tooltip)
+        self.label_2.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_2.setText(QCoreApplication.translate("saving_ui", u"Save Precision", None))
+        self.save_precision_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"fp16", None))
+        self.save_precision_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"bf16", None))
+        self.save_precision_selector.setItemText(2, QCoreApplication.translate("saving_ui", u"float", None))
+
+#if QT_CONFIG(tooltip)
+        self.save_precision_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.label_3.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save As is the file type you save the file as. Typically you'll want to save as safetensors</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_3.setText(QCoreApplication.translate("saving_ui", u"Save As", None))
+        self.save_as_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"safetensors", None))
+        self.save_as_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"pt", None))
+        self.save_as_selector.setItemText(2, QCoreApplication.translate("saving_ui", u"ckpt", None))
+
+#if QT_CONFIG(tooltip)
+        self.save_as_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save As is the file type you save the file as. Typically you'll want to save as safetensors</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.save_ratio_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Ratio is the way to limit the number of models saved</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.save_ratio_enable.setText(QCoreApplication.translate("saving_ui", u"Save Ratio", None))
+#if QT_CONFIG(tooltip)
+        self.save_ratio_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Save Ratio is the way to limit the number of models saved</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.save_freq_enable.setText(QCoreApplication.translate("saving_ui", u"Save Freq", None))
+        self.save_freq_selector.setItemText(0, QCoreApplication.translate("saving_ui", u"Epochs", None))
+        self.save_freq_selector.setItemText(1, QCoreApplication.translate("saving_ui", u"Steps", None))
+
+#if QT_CONFIG(tooltip)
+        self.save_freq_selector.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.save_freq_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
     # retranslateUi
 

--- a/ui_files/SavingUI.py
+++ b/ui_files/SavingUI.py
@@ -116,10 +116,10 @@ class Ui_saving_ui(object):
 
         self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.easy_naming_label)
 
-        self.easy_naming_text_input = LineEditWithHighlight(saving_ui)
-        self.easy_naming_text_input.setObjectName(u"easy_naming_text_input")
+        self.name_replace_text_input = LineEditWithHighlight(saving_ui)
+        self.name_replace_text_input.setObjectName(u"name_replace_text_input")
 
-        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.easy_naming_text_input)
+        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.name_replace_text_input)
 
 
         self.gridLayout_2.addLayout(self.formLayout_2, 0, 0, 1, 2)
@@ -346,13 +346,13 @@ class Ui_saving_ui(object):
 #endif // QT_CONFIG(tooltip)
         self.output_name_input.setPlaceholderText(QCoreApplication.translate("saving_ui", u"Output Name", None))
 #if QT_CONFIG(tooltip)
-        self.easy_naming_label.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Easily rename all instances of ${baseName} variable in files/folders under Saving and Logging</p></body></html>", None))
+        self.easy_naming_label.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Easily rename all instances of ${replace} variable in files/folders under Saving and Logging</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.easy_naming_label.setText(QCoreApplication.translate("saving_ui", u"Easy Naming", None))
+        self.easy_naming_label.setText(QCoreApplication.translate("saving_ui", u"Name Replace", None))
 #if QT_CONFIG(tooltip)
-        self.easy_naming_text_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>What to replace all instances of ${baseName} with. To use, add ${baseName} in each desired textbox</p></body></html>", None))
+        self.name_replace_text_input.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>What to replace all instances of ${replace} with. To use, add ${replace} in each desired textbox</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.easy_naming_text_input.setPlaceholderText(QCoreApplication.translate("saving_ui", u"Base name for model", None))
+        self.name_replace_text_input.setPlaceholderText(QCoreApplication.translate("saving_ui", u"[Optional] Output name replacement string", None))
 #if QT_CONFIG(tooltip)
         self.resume_enable.setToolTip(QCoreApplication.translate("saving_ui", u"<html><head/><body><p>Resume State resumes training at a previous training, assuming you save the state for that bake</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)

--- a/ui_files/SavingUI.ui
+++ b/ui_files/SavingUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>515</width>
-    <height>242</height>
+    <height>296</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -20,229 +20,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
-   <item row="1" column="0">
-    <layout class="QFormLayout" name="formLayout_3">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Save Precision</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="ComboBox" name="save_precision_selector">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>fp16</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>bf16</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>float</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save As is the file type you save the file as. Typically you'll want to save as safetensors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Save As</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="ComboBox" name="save_as_selector">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save As is the file type you save the file as. Typically you'll want to save as safetensors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>safetensors</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>pt</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>ckpt</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="save_ratio_enable">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Ratio is the way to limit the number of models saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Save Ratio</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="SpinBox" name="save_ratio_input">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Ratio is the way to limit the number of models saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="value">
-        <number>1</number>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="save_freq_enable">
-       <property name="text">
-        <string>Save Freq</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>3</number>
-       </property>
-       <item>
-        <widget class="ComboBox" name="save_freq_selector">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <item>
-          <property name="text">
-           <string>Epochs</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Steps</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="SpinBox" name="save_freq_input">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>16777215</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <layout class="QFormLayout" name="formLayout_2">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Output Folder</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>3</number>
-       </property>
-       <item>
-        <widget class="DragDropLineEdit" name="output_folder_input">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="placeholderText">
-          <string>Output Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="output_folder_selector">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="output_name_enable">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Name is the base name of the models that get saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Output Name</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="LineEditWithHighlight" name="output_name_input">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Name is the base name of the models that get saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="placeholderText">
-        <string>Output Name</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="2" column="0" colspan="2">
     <layout class="QFormLayout" name="formLayout_4">
      <item row="0" column="0">
@@ -322,6 +99,96 @@
         </widget>
        </item>
       </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <layout class="QFormLayout" name="formLayout_2">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Output Folder</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="DragDropLineEdit" name="output_folder_input">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="placeholderText">
+          <string>Output Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="output_folder_selector">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Folder is the location the models are saved to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="output_name_enable">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Name is the base name of the models that get saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Output Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="LineEditWithHighlight" name="output_name_input">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Output Name is the base name of the models that get saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="placeholderText">
+        <string>Output Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="easy_naming_label">
+       <property name="minimumSize">
+        <size>
+         <width>97</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Easily rename all instances of ${baseName} variable in files/folders under Saving and Logging&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Easy Naming</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="LineEditWithHighlight" name="easy_naming_text_input">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;What to replace all instances of ${baseName} with. To use, add ${baseName} in each desired textbox&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="placeholderText">
+        <string>Base name for model</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -508,14 +375,168 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="0">
+    <layout class="QFormLayout" name="formLayout_3">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Save Precision</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="ComboBox" name="save_precision_selector">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Precision is the precision the model is saved at, this doesn't neccessarily have to equal the training precision&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>fp16</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>bf16</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>float</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save As is the file type you save the file as. Typically you'll want to save as safetensors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Save As</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="ComboBox" name="save_as_selector">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save As is the file type you save the file as. Typically you'll want to save as safetensors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>safetensors</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>pt</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>ckpt</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="save_ratio_enable">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Ratio is the way to limit the number of models saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Save Ratio</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="SpinBox" name="save_ratio_input">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Ratio is the way to limit the number of models saved&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="save_freq_enable">
+       <property name="text">
+        <string>Save Freq</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="ComboBox" name="save_freq_selector">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Epochs</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Steps</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <widget class="SpinBox" name="save_freq_input">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How often to save models. You can save according to steps or epochs, setting it to epochs and 1 means it will save a model every epoch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>16777215</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>SpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>modules.ScrollOnSelect.h</header>
-  </customwidget>
   <customwidget>
    <class>ComboBox</class>
    <extends>QComboBox</extends>
@@ -530,6 +551,11 @@
    <class>LineEditWithHighlight</class>
    <extends>QLineEdit</extends>
    <header>modules.LineEditHighlight.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>modules.ScrollOnSelect.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/ui_files/SavingUI.ui
+++ b/ui_files/SavingUI.ui
@@ -173,20 +173,20 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Easily rename all instances of ${baseName} variable in files/folders under Saving and Logging&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Easily rename all instances of ${replace} variable in files/folders under Saving and Logging&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Easy Naming</string>
+        <string>Name Replace</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="LineEditWithHighlight" name="easy_naming_text_input">
+      <widget class="LineEditWithHighlight" name="name_replace_text_input">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;What to replace all instances of ${baseName} with. To use, add ${baseName} in each desired textbox&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;What to replace all instances of ${replace} with. To use, add ${replace} in each desired textbox&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="placeholderText">
-        <string>Base name for model</string>
+        <string>[Optional] Output name replacement string</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Thank you for this great repo! I actually prefer your simple UI over kohya_ss. 

## Overview

Recently I was training a bunch of LoRAs and found it tedious to change names of output directories across runs. So I added a way to add a template name under the `Saving Args` section which replaces all instances of the `${baseName}` string in multiple fields referencing input and output files & directories.

![image](https://github.com/user-attachments/assets/05bffa47-48ca-4f0d-ad3f-4c565759d630)

I have been using this to help organize my training runs easily in a structured way:

![image](https://github.com/user-attachments/assets/5261e51d-6c11-4e35-a124-ae04ee366769)

Currently this supports the following fields:
- Output Folder Path
- Output Name
- Resume State Folder Path
- Save Tag File
- Save Toml File
- Prefix For Log Folders

If this sounds like a nice feature to have, I can quickly add it to a few more fields:
- Queue Name
- Name For Log Tracker
- Input Image Dir
- Masked Image Dir
- etc.

## Implementation Details

- If a user doesn't want to use this feature, they can just leave the Easy Naming field blank. It will not overwrite their paths.
- If a user leaves the Easy Naming field blank, but continues to have `${baseName}` in their paths, it will be replaced with an empty string; no exceptions will be thrown.
- `toml`s are saved with the `${baseName}` field intact, so users will not lose their "templates" across runs.

## Questions

- I'm not quite happy with how I've called this feature `Easy Naming`. Am open to suggestions.
- Are there any other fields I should add this feature to that I may have missed?